### PR TITLE
Vue/success

### DIFF
--- a/backend/src/.gitignore
+++ b/backend/src/.gitignore
@@ -1,1 +1,1 @@
-./public
+public

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -198,19 +198,21 @@ const routes = [
         /* webpackChunkName: "about" */ "../views/notice/interview/ApplySuccess.vue"
       ),
   },
-  // success
+  // passcheck
   {
-    path: "/success",
-    name: "success_search",
-    component: () =>
-      import(/* webpackChunkName: "about" */ "../views/success/SearchView.vue"),
-  },
-  {
-    path: "/success/result",
-    name: "success_result",
+    path: "/passcheck",
+    name: "passcheck_search",
     component: () =>
       import(
-        /* webpackChunkName: "about" */ "../views/success/InterviewResult.vue"
+        /* webpackChunkName: "about" */ "../views/passcheck/SearchView.vue"
+      ),
+  },
+  {
+    path: "/passcheck/result/:id",
+    name: "passcheck_result",
+    component: () =>
+      import(
+        /* webpackChunkName: "about" */ "../views/passcheck/InterviewResult.vue"
       ),
   },
   // admin

--- a/vue/src/views/passcheck/InterviewResult.vue
+++ b/vue/src/views/passcheck/InterviewResult.vue
@@ -1,4 +1,3 @@
-vu
 <template>
   <div>
     <HeaderView />
@@ -22,7 +21,7 @@ vu
                   마이페이지
                 </li>
               </router-link>
-              <router-link to="/success">
+              <router-link to="/passcheck">
                 <li class="active">
                   <img
                     src="@/assets/images/icons/menuIcon_search.png"
@@ -76,19 +75,23 @@ vu
               <tbody>
                 <tr class="interview__result-table_tb-td-ei">
                   <td class="interview__result-table_tb-td-001">
-                    2022 명지전문대 입시 면접
+                    {{ result.title }}
                   </td>
-                  <td class="interview__result-table_tb-td-002">합격</td>
+                  <td class="interview__result-table_tb-td-002">
+                    {{ result.result }}
+                  </td>
                   <td class="interview__result-table_tb-td-003">
-                    2022 / 01 / 01
+                    {{ result.applydate }}
                   </td>
-                  <td class="interview__result-table_tb-td-004">김명지</td>
+                  <td class="interview__result-table_tb-td-004">
+                    {{ result.name }}
+                  </td>
                 </tr>
               </tbody>
             </table>
             <div class="interview__result-button">
               <button>
-                <router-link to="/success">뒤로가기</router-link>
+                <router-link to="/passcheck">뒤로가기</router-link>
               </button>
             </div>
             <hr />
@@ -107,6 +110,22 @@ export default {
   components: {
     HeaderView,
     FooterView,
+  },
+  data() {
+    return {
+      passcheck: [],
+      result: {},
+    };
+  },
+  async created() {
+    const passcheckText = await this.$axios.get(
+      "https://667e891c-ab9d-4b30-b8f7-37bd394933f3.mock.pstmn.io/passcheck"
+    );
+    this.passcheck = passcheckText.data.passcheck;
+    this.result = this.passcheck.filter(
+      (v) => v.id === +this.$route.params.id
+    )[0];
+    console.log(this.result);
   },
 };
 </script>

--- a/vue/src/views/passcheck/SearchView.vue
+++ b/vue/src/views/passcheck/SearchView.vue
@@ -1,4 +1,3 @@
-vu
 <template>
   <div>
     <HeaderView />
@@ -22,7 +21,7 @@ vu
                   마이페이지
                 </li>
               </router-link>
-              <router-link to="/success">
+              <router-link to="/passcheck">
                 <li class="active">
                   <img
                     src="@/assets/images/icons/menuIcon_search.png"
@@ -62,14 +61,18 @@ vu
             </div>
             <hr />
             <div class="success__search-select-interview">
-              <router-link to="/success/result">
+              <router-link
+                :to="`/passcheck/result/${passcheck.id}`"
+                :key="index"
+                v-for="(passcheck, index) in passcheck"
+              >
                 <button>
                   <div class="success__search-select-interview-group-1">
-                    <span>2022 명지전문대 입시 면접</span>
-                    <span>합격조회 가능</span>
+                    <span>{{ passcheck.title }}</span>
+                    <span>{{ passcheck.checkstatus }}</span>
                   </div>
                   <div class="success__search-select-interview-group-2">
-                    <span>지원일 : 2022/01/01</span>
+                    <span>지원일 : {{ passcheck.applydate }}</span>
                   </div>
                 </button>
               </router-link>
@@ -90,6 +93,18 @@ export default {
   components: {
     HeaderView,
     FooterView,
+  },
+  data() {
+    return {
+      passcheck: [],
+    };
+  },
+  async created() {
+    const passcheckText = await this.$axios.get(
+      "https://667e891c-ab9d-4b30-b8f7-37bd394933f3.mock.pstmn.io/passcheck"
+    );
+    this.passcheck = passcheckText.data.passcheck;
+    console.log(this.passcheck.id);
   },
 };
 </script>


### PR DESCRIPTION
Add dummy API to the successful candidate lookup list
Click the button to move to each interview result

합격자 조회 목록에 dummy API 추가
버튼을 클릭하여 각각의 면접 결과로 이동